### PR TITLE
fix to subscribe UIDeviceOrientationDidChange notification after label setup

### DIFF
--- a/SwiftyDrop/Drop.swift
+++ b/SwiftyDrop/Drop.swift
@@ -74,7 +74,6 @@ public final class Drop: UIView {
         
         scheduleUpTimer(duration)
         NotificationCenter.default.addObserver(self, selector: #selector(UIApplicationDelegate.applicationDidEnterBackground(_:)), name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(Drop.deviceOrientationDidChange(_:)), name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
     }
     
     override init(frame: CGRect) {
@@ -272,6 +271,7 @@ extension Drop {
             ]
         )
         self.statusLabel = statusLabel
+        NotificationCenter.default.addObserver(self, selector: #selector(Drop.deviceOrientationDidChange(_:)), name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
         
         self.layoutIfNeeded()
         self.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.up(_:))))


### PR DESCRIPTION
Moved UIDeviceOrientationDidChange subscription from 'Drop.init()' to end of 'Drop.setup()'.

Because the updateHeight() called from deviceOrientationDidChange(_:) handler can access uninitialized statusLabel when setup() has not been completed yet.

https://github.com/morizotter/SwiftyDrop/issues/51
