### PR TITLE
Completion handler

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -81,10 +81,27 @@ class ViewController: UIViewController {
         let durationAction = UIAlertAction(title: "Duration", style: .default) { [unowned self] action -> Void in
             self.showDurationAlert()
         }
+        let completionAction = UIAlertAction(title: "Completion", style: .default) { [unowned self] action -> Void in
+            Drop.down(self.sampleText(), completion: { type in
+                let firedBy: String = {
+                    switch type {
+                    case .timeout:
+                        return "timeout"
+                    case .user:
+                        return "user"
+                    }
+                }()
+
+                let action = UIAlertAction(title: "OK", style: .default, handler: nil)
+                let controller = UIAlertController(title: "Action", message: "Completion fired by \(firedBy)!", preferredStyle: .alert)
+                controller.addAction(action)
+                self.present(controller, animated: true, completion: nil)
+            })
+        }
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         
         let controller = UIAlertController(title: "Samples", message: "Select to show drop down message.", preferredStyle: .actionSheet)
-        for action in [defaultAction, infoAction, successAction, warningAction, errorAction, colorAction, actionableAction, blurAction, customAction, durationAction, cancelAction] {
+        for action in [defaultAction, infoAction, successAction, warningAction, errorAction, colorAction, actionableAction, blurAction, customAction, durationAction, completionAction, cancelAction] {
             controller.addAction(action)
         }
         showAlert(controller, sourceView: sender as? UIView)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ Drop.down("Message") {
 }
 ```
 
+### Completion
+```swift
+Drop.down("Message", completion: { type in
+    switch type {
+    case .timeout:
+        print("Completion by timeout!")
+    case .user:
+        print("Completion by user!")
+    }
+}
+```
+
+You can get notified when the message times out or is swiped away by user.
+
 ## Contribution
 
 Please file issues or submit pull requests! We're waiting! :)

--- a/SwiftyDrop/Drop.swift
+++ b/SwiftyDrop/Drop.swift
@@ -51,6 +51,9 @@ public enum DropState: DropStatable {
 
 public typealias DropAction = () -> Void
 
+public typealias DropCompletion = (DropCompletionType) -> Void
+public enum DropCompletionType { case timeout, user }
+
 public final class Drop: UIView {
     static let PRESET_DURATION: TimeInterval = 4.0
     
@@ -67,6 +70,7 @@ public final class Drop: UIView {
     fileprivate var startTop: CGFloat?
 
     fileprivate var action: DropAction?
+    fileprivate var completion: DropCompletion?
 
     convenience init(duration: Double) {
         self.init(frame: CGRect.zero)
@@ -104,6 +108,7 @@ public final class Drop: UIView {
     
     @objc func upFromTimer(_ timer: Timer) {
         if let interval = timer.userInfo as? Double {
+            completion?(.timeout)
             Drop.up(self, interval: interval)
         }
     }
@@ -134,15 +139,15 @@ public final class Drop: UIView {
 }
 
 extension Drop {
-    public class func down(_ status: String, state: DropState = .default, duration: Double = 4.0, action: DropAction? = nil) {
-        show(status, state: state, duration: duration, action: action)
+    public class func down(_ status: String, state: DropState = .default, duration: Double = 4.0, completion: DropCompletion? = nil, action: DropAction? = nil) {
+        show(status, state: state, duration: duration, completion: completion, action: action)
     }
 
-    public class func down<T: DropStatable>(_ status: String, state: T, duration: Double = 4.0, action: DropAction? = nil) {
-        show(status, state: state, duration: duration, action: action)
+    public class func down<T: DropStatable>(_ status: String, state: T, duration: Double = 4.0, completion: DropCompletion? = nil, action: DropAction? = nil) {
+        show(status, state: state, duration: duration, completion: completion, action: action)
     }
 
-    fileprivate class func show(_ status: String, state: DropStatable, duration: Double, action: DropAction?) {
+    fileprivate class func show(_ status: String, state: DropStatable, duration: Double, completion: DropCompletion?, action: DropAction?) {
         self.upAll()
         let drop = Drop(duration: duration)
         UIApplication.shared.keyWindow?.addSubview(drop)
@@ -165,6 +170,7 @@ extension Drop {
 
         drop.setup(status, state: state)
         drop.action = action
+        drop.completion = completion
         drop.updateHeight()
         
         guard let superview = drop.superview else { return }
@@ -305,6 +311,7 @@ extension Drop {
             startTop = nil
             guard let topConstraint = topConstraint else { return }
             if topConstraint.constant < 0.0 {
+                completion?(.user)
                 scheduleUpTimer(0.0, interval: 0.1)
             } else {
                 scheduleUpTimer(duration)


### PR DESCRIPTION
Added a completion handler to the dropdown, as discussed in #55 

I kept action as the last parameter to `drop()`, so that we don't break anyone using trailing closure syntax. Based on a compile of my own project that uses SwiftyDrop, this doesn't seem to be a breaking change, but I'm not sure how adding this optional parameter will affect other projects.